### PR TITLE
Сhange socket=x11 to socket=fallback-x11, and change filesystem=home to filesystem=host

### DIFF
--- a/com.redis.RedisInsight.yml
+++ b/com.redis.RedisInsight.yml
@@ -9,11 +9,12 @@ separate-locales: false
 finish-args:
   - --share=ipc
   - --share=network
-  - --filesystem=home
+  - --filesystem=host
   - --device=dri
   - --talk-name=org.freedesktop.secrets
   - --talk-name=org.freedesktop.Notifications
-  - --socket=x11
+  - --socket=wayland
+  - --socket=fallback-x11
 modules:
   - name: redis insight
     buildsystem: simple


### PR DESCRIPTION
Covering the following alerts:

```
Home folder read/write access
Can read and write all data in your home folder
```
```
Legacy windowing system
Uses a legacy windowing system
```

Nothing changed in terms of features or Redis Insight behavior.