### PR TITLE
Catch up to v3.4.2

### DIFF
--- a/com.redis.RedisInsight.metainfo.xml
+++ b/com.redis.RedisInsight.metainfo.xml
@@ -80,6 +80,66 @@
     <content_rating type="oars-1.1"/>
 
     <releases>
+        <release version="3.4.2" date="2026-04-22">
+            <description>
+                <ul>
+                    <li>Fixed issues with the Windows auto-update, so the new version is delivered automatically the next time the app is started.</li>
+                </ul>
+            </description>
+        </release>
+        <release version="3.4.1" date="2026-04-20">
+            <description>
+                <ul>
+                    <li>New dedicated Search workspace with full index lifecycle support: create indexes from sample data or existing user data, query indexed data with an assisted editor, and save queries to a Query Library for reuse.</li>
+                    <li>Navigate between Browser and Search workspaces: review indexed data in the Browser, view indexed keys and their associated indexes, and create indexes directly from the Browser key list.</li>
+                    <li>Azure Entra ID authentication support for Docker deployments, Access Key authentication as an alternative to Entra ID, and a manual connection form for Azure Redis databases.</li>
+                    <li>Added Linux ARM64 release support with AppImage, deb, and rpm packages.</li>
+                    <li>Client-side column sorting for the Browser key list by Key, TTL, or Size directly from the Columns popover.</li>
+                    <li>Workbench output settings now persist between commands and no longer crash when external plugins are loaded.</li>
+                </ul>
+            </description>
+        </release>
+        <release version="3.2.0" date="2026-02-26">
+            <description>
+                <ul>
+                    <li>Added support for Azure Managed Redis and Azure Cache for Redis tiers, including auto-discovery of databases across subscriptions with one-click import.</li>
+                    <li>Microsoft Entra ID (OAuth) authentication with automatic background token refresh, and multi-account support to switch between Azure accounts.</li>
+                    <li>Simplified the build process by removing the Webpack dependency - Vite is now used for both development and production builds.</li>
+                    <li>Addressed critical security vulnerabilities by upgrading Node.js and the Alpine base image used in Docker.</li>
+                </ul>
+            </description>
+        </release>
+        <release version="3.0.3" date="2026-02-16">
+            <description>
+                <ul>
+                    <li>Redis Data Integration now uses API v2 when available, showing detailed pipeline status, component statuses, and richer metrics on the Statistics page.</li>
+                    <li>Bulk delete from Tree View: delete all keys under a folder or namespace via a delete action on the folder, which opens Bulk Actions with the pattern pre-filled.</li>
+                    <li>LZ4 decompression support for MessagePack-CSharp format, so LZ4-compressed MessagePack values display correctly.</li>
+                    <li>Restored Pub/Sub functionality: message clear option, full message display with line wrapping, and descending chronological order.</li>
+                    <li>Fallback to DEL when UNLINK is unavailable, restoring compatibility with Redis 3.2.12 and similar versions.</li>
+                    <li>Default database sorting now places the most recently used databases at the top of the list.</li>
+                </ul>
+            </description>
+        </release>
+        <release version="3.0.2" date="2026-01-08">
+            <description>
+                <ul>
+                    <li>Fixed a SQLite package "not found" error on macOS x64 builds.</li>
+                    <li>Corrected CPU metrics that were inaccurate when Redis I/O threads or cluster shards pushed usage above 100%.</li>
+                    <li>Delimiter options now persist when switching between databases.</li>
+                    <li>Enabled dual-stack IPv4/IPv6 support in ioredis connections.</li>
+                </ul>
+            </description>
+        </release>
+        <release version="3.0.0" date="2025-12-04">
+            <description>
+                <ul>
+                    <li>Major UI refresh with modernized visuals and a more intuitive workflow for inspecting keys, debugging data, and moving quickly between tasks. The design aligns Redis Insight with the Redis Cloud experience.</li>
+                    <li>New top-level navigation replaces the left sidebar, making high-usage tools like Browser and Workbench easier to discover and access.</li>
+                    <li>Electron upgrade that resolves a macOS 26 compatibility issue, improved database list search for not-connected databases, and fixes for Redis Data Integration 1.14+ job reopening.</li>
+                </ul>
+            </description>
+        </release>
         <release version="2.70.1" date="2025-07-11">
             <description>
                 <ul>

--- a/com.redis.RedisInsight.yml
+++ b/com.redis.RedisInsight.yml
@@ -1,9 +1,9 @@
 app-id: com.redis.RedisInsight
 runtime: org.freedesktop.Platform
-runtime-version: '24.08'
+runtime-version: '25.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '24.08'
+base-version: '25.08'
 command: redisinsight
 separate-locales: false
 finish-args:
@@ -39,13 +39,23 @@ modules:
     sources:
       - type: file
         only-arches: [x86_64]
-        url: https://download.redisinsight.redis.com/latest/Redis-Insight-linux-x86_64.AppImage
-        sha512: 84427f22fc062844609a5ebb948d7a64d5e8b11a43444acfaf966afa93639f44d35ae09363091f9f55007adbf052b3c87437b06b6afdd65408d010d8976466d1
+        url: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-x86_64.AppImage
+        sha512: c6a5d057399785414cecb61f7bdb85c3c6128e121ac197a51cfbe73470885d6a670ce01f521660d9f65fe27876e636a64b7057ddc9a125b74aeeed6796cdd832
         dest_filename: RedisInsight.AppImage
         x-checker-data:
           type: rotating-url
-          url: https://download.redisinsight.redis.com/latest/Redis-Insight-linux-x86_64.AppImage
-          pattern: https://download.redisinsight.redis.com/latest/Redis-Insight-linux-x86_64.AppImage
+          url: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-x86_64.AppImage
+          pattern: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-x86_64.AppImage
+
+      - type: file
+        only-arches: [aarch64]
+        url: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-arm64.AppImage
+        sha512: 0727ac2c61decda8954b2d86f8308b5f217b371814481e09be9ae1cadaba00b96e8f22a695e5f4381c321e4f459096c98e085e5372e5ad461b014ea6ad3839f0
+        dest_filename: RedisInsight.AppImage
+        x-checker-data:
+          type: rotating-url
+          url: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-arm64.AppImage
+          pattern: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-arm64.AppImage
 
       - type: file
         path: redisinsight.sh

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,4 @@
 {
   "automerge-flathubbot-prs": true,
-  "only-arches": ["x86_64"]
+  "only-arches": ["x86_64", "aarch64"]
 }


### PR DESCRIPTION
## Summary

Brings the Flathub build of Redis Insight current after the repo's unarchival. Four related changes rolled into one PR:

1. **Runtime bump 24.08 -> 25.08** for both `org.freedesktop.Platform` and `org.electronjs.Electron2.BaseApp` (24.08 is aging out; 25.08 is the current default on Flathub).
2. **Update the x86_64 AppImage source** — the previous `download.redisinsight.redis.com/latest/...` URL was pinned to 2.70.1 because upstream rolled the default "latest" target to the v3 major-version prefix. Switched to `latest-v3/Redis-Insight-linux-x86_64.AppImage` with the correct sha512 for 3.4.2.
3. **Add a new aarch64 AppImage source** and extend `flathub.json`'s `only-arches` to include `aarch64`. Upstream ships `Redis-Insight-linux-arm64.AppImage` in the same `latest-v3/` directory.
4. **Prepend six `<release>` entries** to the metainfo (`3.4.2`, `3.4.1`, `3.2.0`, `3.0.3`, `3.0.2`, `3.0.0`), condensed from the upstream GitHub release notes into the same user-facing bullet style used by the existing `2.70.1` block (no issue IDs, no checksum links, 3-6 bullets each).

## Checklist

- [x] Updated `com.redis.RedisInsight.yml` (runtime, x86_64 source, aarch64 source)
- [x] Updated `flathub.json` (only-arches extended)
- [x] Updated `com.redis.RedisInsight.metainfo.xml` (six new `<release>` entries, descending order)
- [x] Flathub CI x86_64 build passes
- [x] Flathub CI aarch64 build passes
- [x] `appstreamcli` metainfo validation passes
- [x] `flatpak-builder-lint` passes


Made with [Cursor](https://cursor.com)