### PR TITLE
Drop shared-modules and more

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/flathub.json
+++ b/flathub.json
@@ -1,4 +1,3 @@
 {
-  "automerge-flathubbot-prs": true,
-  "only-arches": ["x86_64", "aarch64"]
+  "automerge-flathubbot-prs": true
 }


### PR DESCRIPTION
- Drop redundant shared-modules
- Drop only-arches limitations since the both arches are provided