### PR TITLE
Update to v3.6.0

### DIFF
--- a/com.redis.RedisInsight.metainfo.xml
+++ b/com.redis.RedisInsight.metainfo.xml
@@ -80,6 +80,17 @@
     <content_rating type="oars-1.1"/>
 
     <releases>
+        <release version="3.6.0" date="2026-06-15">
+            <description>
+                <ul>
+                    <li>Full support for Vector Sets, the new Redis 8 vector-native data type: create them manually or from a bundled sample dataset, add elements, and run similarity search by raw vector or element name.</li>
+                    <li>New Dev vs Production database mode with safety guardrails: classify databases by environment, with PROD and Development labels and a type-to-confirm prompt before destructive actions on production.</li>
+                    <li>New Geodata Workbench plugin renders Redis GEO command results as an interactive map, density heatmap, or details card.</li>
+                    <li>Added Copy and Download value actions for JSON keys, plus a Copy value action for String keys.</li>
+                    <li>Settings now shows the build commit SHA next to the app version, and fixed missing scrollbars on the database list and other tables at constrained viewport heights.</li>
+                </ul>
+            </description>
+        </release>
         <release version="3.4.2" date="2026-04-22">
             <description>
                 <ul>

--- a/com.redis.RedisInsight.yml
+++ b/com.redis.RedisInsight.yml
@@ -42,7 +42,7 @@ modules:
       - type: file
         only-arches: [x86_64]
         url: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-x86_64.AppImage
-        sha512: c6a5d057399785414cecb61f7bdb85c3c6128e121ac197a51cfbe73470885d6a670ce01f521660d9f65fe27876e636a64b7057ddc9a125b74aeeed6796cdd832
+        sha512: 5fc04e3c879b72d3ad17e8ddeb8363d8a8e5d6c010688fb7002f1542b269a84d1c366a09516382ba24b30d413f7b1986e778252556f40d0e1bda6e2cf566abd9
         dest_filename: RedisInsight.AppImage
         x-checker-data:
           type: rotating-url
@@ -52,7 +52,7 @@ modules:
       - type: file
         only-arches: [aarch64]
         url: https://download.redisinsight.redis.com/latest-v3/Redis-Insight-linux-arm64.AppImage
-        sha512: 0727ac2c61decda8954b2d86f8308b5f217b371814481e09be9ae1cadaba00b96e8f22a695e5f4381c321e4f459096c98e085e5372e5ad461b014ea6ad3839f0
+        sha512: 211955863e8b30d3622896c66f8a86990aab6d9081456354f6d753547300ed7bd19db3c47472c149962748baa82b506a29cf0044745634139787ac71bcd03482
         dest_filename: RedisInsight.AppImage
         x-checker-data:
           type: rotating-url


### PR DESCRIPTION
## Summary

Bumps the Flathub build of Redis Insight to **3.6.0** (released 2026-06-15). Two related changes:

1. **Update the AppImage `sha512` checksums** for both `x86_64` and `aarch64`. The rolling `latest-v3/Redis-Insight-linux-*.AppImage` URLs are unchanged — only the pinned checksums move, since the values on `master` were still those of 3.4.2. New checksums were computed from the current artifacts (`last-modified: 2026-06-15`, matching the release).
2. **Prepend a `<release>` entry for 3.6.0** to the metainfo, condensed from the upstream GitHub release notes into the same user-facing bullet style as the existing entries (no issue IDs, no checksum links, 3–6 bullets).

### 3.6.0 highlights
- Full support for **Vector Sets**, the new Redis 8 vector-native data type.
- New **Dev vs Production** database mode with type-to-confirm guardrails on production.
- New **Geodata Workbench** plugin for rendering Redis `GEO` results.
- Copy/Download value actions for `JSON` and `String` keys.

## Checklist

- [x] Updated `com.redis.RedisInsight.yml` (x86_64 + aarch64 `sha512`)
- [x] Updated `com.redis.RedisInsight.metainfo.xml` (new 3.6.0 `<release>` entry, descending order)
- [x] `xmllint` well-formedness check passes
- [ ] Flathub CI x86_64 build passes
- [ ] Flathub CI aarch64 build passes
- [ ] `appstreamcli` metainfo validation passes
- [ ] `flatpak-builder-lint` passes

Upstream release: https://github.com/redis/RedisInsight/releases/tag/3.6.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)